### PR TITLE
[Task_2] Basic Infrastructure Configuration

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
+        working-directory: networking
 
   terraform-plan:
     name: Terraform Plan
@@ -45,9 +46,11 @@ jobs:
 
       - name: Terraform Init
         run: terraform init
+        working-directory: networking
 
       - name: Terraform Plan
         run: terraform plan
+        working-directory: networking
 
   terraform-apply:
     name: Terraform Apply
@@ -70,6 +73,8 @@ jobs:
 
       - name: Terraform Init
         run: terraform init
+        working-directory: networking
 
       - name: Terraform Apply
         run: terraform apply -auto-approve
+        working-directory: networking

--- a/networking/README.md
+++ b/networking/README.md
@@ -1,0 +1,49 @@
+# Terraform AWS VPC Setup
+
+## Overview
+
+This Terraform project provisions the following infrastructure in AWS:
+
+- A VPC with CIDR block `10.0.0.0/16`.
+- Two public subnets in different Availability Zones.
+- Two private subnets in different Availability Zones.
+- An Internet Gateway attached to the VPC.
+- Route tables configured for public and private subnets.
+- A NAT Gateway in a public subnet for private subnet internet access.
+- Security Groups configured for the Bastion Host and internal communication.
+- Network ACLs allowing traffic between subnets and to/from the internet.
+- A Bastion Host in a public subnet for secure SSH access to private instances.
+
+---
+
+## Architecture Overview
+
+- Instances in public subnets have direct internet access via the Internet Gateway.
+- Instances in private subnets access the internet through the NAT Gateway.
+- The Bastion Host resides in a public subnet with SSH access restricted to your IP address.
+- Instances in private subnets can be accessed securely via the Bastion Host.
+
+---
+
+## Prerequisites
+
+- AWS account with permissions to create VPCs, subnets, gateways, route tables, EC2 instances, security groups, and related resources.
+- Terraform installed (version 1.0 or higher recommended).
+- Update variables in `variables.tf` as needed:
+   - `aws_region`: AWS region to deploy resources (default: `us-east-1`).
+   - `ssh_key_name`: Your existing EC2 key pair name for SSH access.
+   - `my_ip`: Your public IP address in CIDR notation (e.g., `x.x.x.x/32`) to restrict SSH access to the Bastion Host.
+   - CIDR blocks and Availability Zones for public and private subnets.
+
+---
+
+## Usage
+
+From the CLI, run:
+
+```bash
+terraform plan
+terraform apply
+```
+
+Or use rerraform.yml in CI/CD 

--- a/networking/bastion.tf
+++ b/networking/bastion.tf
@@ -1,0 +1,39 @@
+# Security Group for Bastion Host
+resource "aws_security_group" "bastion_sg" {
+  name        = "bastion-sg"
+  description = "Allow SSH from specific IP"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "SSH from your IP"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = [var.my_ip]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "bastion-sg"
+  }
+}
+
+# EC2 Bastion Host in Public Subnet
+resource "aws_instance" "bastion" {
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = "t3.micro"
+  subnet_id              = aws_subnet.public_subnet1.id
+  key_name               = var.ssh_key_name
+  associate_public_ip_address = true
+  vpc_security_group_ids = [aws_security_group.bastion_sg.id]
+
+  tags = {
+    Name = "bastion-host"
+  }
+}

--- a/networking/bastion.tf
+++ b/networking/bastion.tf
@@ -5,11 +5,11 @@ resource "aws_security_group" "bastion_sg" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
-    description      = "SSH from your IP"
-    from_port        = 22
-    to_port          = 22
-    protocol         = "tcp"
-    cidr_blocks      = [var.my_ip]
+    description = "SSH from your IP"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
   }
 
   egress {
@@ -26,12 +26,12 @@ resource "aws_security_group" "bastion_sg" {
 
 # EC2 Bastion Host in Public Subnet
 resource "aws_instance" "bastion" {
-  ami                    = data.aws_ami.amazon_linux.id
-  instance_type          = "t3.micro"
-  subnet_id              = aws_subnet.public_subnet1.id
-  key_name               = var.ssh_key_name
+  ami                         = data.aws_ami.amazon_linux.id
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.public_subnet1.id
+  key_name                    = var.ssh_key_name
   associate_public_ip_address = true
-  vpc_security_group_ids = [aws_security_group.bastion_sg.id]
+  vpc_security_group_ids      = [aws_security_group.bastion_sg.id]
 
   tags = {
     Name = "bastion-host"

--- a/networking/data_sources.tf
+++ b/networking/data_sources.tf
@@ -1,0 +1,15 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["amazon"]
+}

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/networking/nat.tf
+++ b/networking/nat.tf
@@ -1,0 +1,38 @@
+resource "aws_eip" "nat" {
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_nat_gateway" "nat_gw" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public_subnet1.id  # NAT GW in a public subnet
+
+  tags = {
+    Name = "nat-gateway"
+  }
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "private-route-table"
+  }
+}
+
+resource "aws_route" "private_nat_route" {
+  route_table_id         = aws_route_table.private_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat_gw.id
+
+  depends_on = [aws_nat_gateway.nat_gw]
+}
+
+resource "aws_route_table_association" "private_subnet1_assoc" {
+  subnet_id      = aws_subnet.private_subnet1.id
+  route_table_id = aws_route_table.private_rt.id
+}
+
+resource "aws_route_table_association" "private_subnet2_assoc" {
+  subnet_id      = aws_subnet.private_subnet2.id
+  route_table_id = aws_route_table.private_rt.id
+}

--- a/networking/nat.tf
+++ b/networking/nat.tf
@@ -4,7 +4,7 @@ resource "aws_eip" "nat" {
 
 resource "aws_nat_gateway" "nat_gw" {
   allocation_id = aws_eip.nat.id
-  subnet_id     = aws_subnet.public_subnet1.id  # NAT GW in a public subnet
+  subnet_id     = aws_subnet.public_subnet1.id # NAT GW in a public subnet
 
   tags = {
     Name = "nat-gateway"

--- a/networking/outputs.tf
+++ b/networking/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = [aws_subnet.public_subnet1.id, aws_subnet.public_subnet2.id]
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = [aws_subnet.private_subnet1.id, aws_subnet.private_subnet2.id]
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.gw.id
+}
+
+output "nat_gateway_id" {
+  description = "The ID of the NAT Gateway"
+  value       = aws_nat_gateway.nat_gw.id
+}
+
+output "bastion_public_ip" {
+  description = "Public IP of the Bastion Host"
+  value       = aws_instance.bastion.public_ip
+}

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -1,0 +1,32 @@
+variable "aws_region" {
+  description = "The AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "ssh_key_name" {
+  description = "Name of the SSH key pair"
+  type        = string
+  default = "ec2-rss"
+}
+
+variable "my_ip" {
+  description = "Your IP address to allow SSH (format: x.x.x.x/32)"
+  type        = string
+  default = "188.212.135.156/32"
+}
+
+variable "public_subnet_cidrs" {
+  type    = list(string)
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type    = list(string)
+  default = ["10.0.3.0/24", "10.0.4.0/24"]
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["us-east-1a", "us-east-1b"]
+}

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -7,13 +7,13 @@ variable "aws_region" {
 variable "ssh_key_name" {
   description = "Name of the SSH key pair"
   type        = string
-  default = "ec2-rss"
+  default     = "ec2-rss"
 }
 
 variable "my_ip" {
   description = "Your IP address to allow SSH (format: x.x.x.x/32)"
   type        = string
-  default = "188.212.135.156/32"
+  default     = "188.212.135.156/32"
 }
 
 variable "public_subnet_cidrs" {

--- a/networking/vpc.tf
+++ b/networking/vpc.tf
@@ -1,0 +1,76 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "main-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main-gw"
+  }
+}
+
+resource "aws_subnet" "public_subnet1" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[0]
+  availability_zone       = var.availability_zones[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-subnet1"
+  }
+}
+
+resource "aws_subnet" "public_subnet2" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[1]
+  availability_zone       = var.availability_zones[1]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-subnet2"
+  }
+}
+
+resource "aws_subnet" "private_subnet1" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[0]
+  availability_zone = var.availability_zones[0]
+
+  tags = {
+    Name = "private-subnet1"
+  }
+}
+
+resource "aws_subnet" "private_subnet2" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[1]
+  availability_zone = var.availability_zones[1]
+
+  tags = {
+    Name = "private-subnet2"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+}
+
+resource "aws_route_table_association" "public_subnet1_assoc" {
+  subnet_id      = aws_subnet.public_subnet1.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_subnet2_assoc" {
+  subnet_id      = aws_subnet.public_subnet2.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
1. **Terraform Code Implementation (50 points)**

   ✅ Terraform code is created to configure the following: 
     - VPC ("main")
     - 2 public subnets in different AZs ("public_subnet1", "public_subnet2")
     - 2 private subnets in different AZs ("private_subnet1", "private_subnet2" )
     - Internet Gateway ("aws_internet_gateway" "gw")
     - Routing configuration:
       - Instances in all subnets can reach each other (Same VPC + test ping between instances)
       - Instances in public subnets can reach addresses outside the VPC and vice-versa (Route table → IGW, public IP assigned, SG rules, SG allows inbound, public IP present)

2. **Code Organization (10 points)**

   - ✅  Variables are defined in a separate variables [file](https://github.com/Kristy-user/rsschool-devops-course-tasks/blob/task_2/networking/variables.tf).
   - ✅  Resources are separated into different files for better organization.

3. **Verification (10 points)**

   - ✅  Terraform plan is executed successfully (See [Action ](https://github.com/Kristy-user/rsschool-devops-course-tasks/actions/runs/15796291996/job/44528718681) or below in description) .
   - ✅ A resource map screenshot is provided (VPC -> Your VPCs -> your_VPC_name -> Resource map)
   
![image](https://github.com/user-attachments/assets/16ba06f4-ab5b-4c9c-b682-4e18707a4a23)


4. **Additional Tasks (30 points)💫**
   - ✅ **Security Groups and Network ACLs (5 points)** (vpc_security_group_ids = [aws_security_group.bastion_sg.id], "public_acl")
   - ✅ **Bastion Host (5 points)** ([bastion.tf](https://github.com/Kristy-user/rsschool-devops-course-tasks/blob/task_2/networking/bastion.tf)).
   - ✅ **NAT is implemented for private subnets (10 points)** ([nat.tf](https://github.com/Kristy-user/rsschool-devops-course-tasks/blob/task_2/networking/nat.tf))
   - ✅ **Documentation (5 points)** ([README.md](https://github.com/Kristy-user/rsschool-devops-course-tasks/blob/task_2/networking/README.md))
   - ✅**Submission (5 points)**
   - A GitHub [Actions](https://github.com/Kristy-user/rsschool-devops-course-tasks/actions/runs/15796291996) (GHA) pipeline is set up for the Terraform code.
   
   
   Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eip.nat will be created
  + resource "aws_eip" "nat" {
      + allocation_id        = (known after apply)
      + arn                  = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + ipam_pool_id         = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + ptr_record           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + region               = "us-east-1"
      + tags_all             = (known after apply)
    }

  # aws_instance.bastion will be created
  + resource "aws_instance" "bastion" {
      + ami                                  = "ami-02b3c03c6fadb6e2c"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + enable_primary_ipv6                  = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t3.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "ec2-rss"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + region                               = "us-east-1"
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "bastion-host"
        }
      + tags_all                             = {
          + "Name" = "bastion-host"
        }
      + tenancy                              = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification (known after apply)

      + cpu_options (known after apply)

      + ebs_block_device (known after apply)

      + enclave_options (known after apply)

      + ephemeral_block_device (known after apply)

      + instance_market_options (known after apply)

      + maintenance_options (known after apply)

      + metadata_options (known after apply)

      + network_interface (known after apply)

      + private_dns_name_options (known after apply)

      + root_block_device (known after apply)
    }

  # aws_internet_gateway.gw will be created
  + resource "aws_internet_gateway" "gw" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + region   = "us-east-1"
      + tags     = {
          + "Name" = "main-gw"
        }
      + tags_all = {
          + "Name" = "main-gw"
        }
      + vpc_id   = (known after apply)
    }

  # aws_nat_gateway.nat_gw will be created
  + resource "aws_nat_gateway" "nat_gw" {
      + allocation_id                      = (known after apply)
      + association_id                     = (known after apply)
      + connectivity_type                  = "public"
      + id                                 = (known after apply)
      + network_interface_id               = (known after apply)
      + private_ip                         = (known after apply)
      + public_ip                          = (known after apply)
      + region                             = "us-east-1"
      + secondary_private_ip_address_count = (known after apply)
      + secondary_private_ip_addresses     = (known after apply)
      + subnet_id                          = (known after apply)
      + tags                               = {
          + "Name" = "nat-gateway"
        }
      + tags_all                           = {
          + "Name" = "nat-gateway"
        }
    }

  # aws_route.private_nat_route will be created
  + resource "aws_route" "private_nat_route" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + nat_gateway_id         = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + region                 = "us-east-1"
      + route_table_id         = (known after apply)
      + state                  = (known after apply)
    }

  # aws_route_table.private_rt will be created
  + resource "aws_route_table" "private_rt" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + region           = "us-east-1"
      + route            = (known after apply)
      + tags             = {
          + "Name" = "private-route-table"
        }
      + tags_all         = {
          + "Name" = "private-route-table"
        }
      + vpc_id           = (known after apply)
    }

  # aws_route_table.public will be created
  + resource "aws_route_table" "public" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + region           = "us-east-1"
      + route            = [
          + {
              + cidr_block                 = "0.0.0.0/0"
              + gateway_id                 = (known after apply)
                # (11 unchanged attributes hidden)
            },
        ]
      + tags_all         = (known after apply)
      + vpc_id           = (known after apply)
    }

  # aws_route_table_association.private_subnet1_assoc will be created
  + resource "aws_route_table_association" "private_subnet1_assoc" {
      + id             = (known after apply)
      + region         = "us-east-1"
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_route_table_association.private_subnet2_assoc will be created
  + resource "aws_route_table_association" "private_subnet2_assoc" {
      + id             = (known after apply)
      + region         = "us-east-1"
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_route_table_association.public_subnet1_assoc will be created
  + resource "aws_route_table_association" "public_subnet1_assoc" {
      + id             = (known after apply)
      + region         = "us-east-1"
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_route_table_association.public_subnet2_assoc will be created
  + resource "aws_route_table_association" "public_subnet2_assoc" {
      + id             = (known after apply)
      + region         = "us-east-1"
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_security_group.bastion_sg will be created
  + resource "aws_security_group" "bastion_sg" {
      + arn                    = (known after apply)
      + description            = "Allow SSH from specific IP"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
                # (1 unchanged attribute hidden)
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "188.212.135.156/32",
                ]
              + description      = "SSH from your IP"
              + from_port        = 22
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 22
            },
        ]
      + name                   = "bastion-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + region                 = "us-east-1"
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "bastion-sg"
        }
      + tags_all               = {
          + "Name" = "bastion-sg"
        }
      + vpc_id                 = (known after apply)
    }

  # aws_subnet.private_subnet1 will be created
  + resource "aws_subnet" "private_subnet1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.3.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + region                                         = "us-east-1"
      + tags                                           = {
          + "Name" = "private-subnet1"
        }
      + tags_all                                       = {
          + "Name" = "private-subnet1"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.private_subnet2 will be created
  + resource "aws_subnet" "private_subnet2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.4.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + region                                         = "us-east-1"
      + tags                                           = {
          + "Name" = "private-subnet2"
        }
      + tags_all                                       = {
          + "Name" = "private-subnet2"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.public_subnet1 will be created
  + resource "aws_subnet" "public_subnet1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + region                                         = "us-east-1"
      + tags                                           = {
          + "Name" = "public-subnet1"
        }
      + tags_all                                       = {
          + "Name" = "public-subnet1"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.public_subnet2 will be created
  + resource "aws_subnet" "public_subnet2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.2.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + region                                         = "us-east-1"
      + tags                                           = {
          + "Name" = "public-subnet2"
        }
      + tags_all                                       = {
          + "Name" = "public-subnet2"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.main will be created
  + resource "aws_vpc" "main" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/[16](https://github.com/Kristy-user/rsschool-devops-course-tasks/actions/runs/15796291996/job/44528718681#step:6:17)"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + region                               = "us-east-1"
      + tags                                 = {
          + "Name" = "main-vpc"
        }
      + tags_all                             = {
          + "Name" = "main-vpc"
        }
    }

Plan: [17](https://github.com/Kristy-user/rsschool-devops-course-tasks/actions/runs/15796291996/job/44528718681#step:6:18) to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bastion_public_ip   = (known after apply)
  + internet_gateway_id = (known after apply)
  + nat_gateway_id      = (known after apply)
  + private_subnet_ids  = [
      + (known after apply),
      + (known after apply),
    ]
  + public_subnet_ids   = [
      + (known after apply),
      + (known after apply),
    ]
  + vpc_id              = (known after apply)